### PR TITLE
Fix effect invocation syntax

### DIFF
--- a/src/hooks/use-mobile.jsx
+++ b/src/hooks/use-mobile.jsx
@@ -13,7 +13,7 @@ export function useIsMobile() {
     mql.addEventListener("change", onChange)
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange);
-  }, [])
+  }, []);
 
   return !!isMobile
 }


### PR DESCRIPTION
## Summary
- fix `useIsMobile` effect invocation to end with semicolon

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68457d4c85e08327ae0878e4c0e22895